### PR TITLE
Anchor regexp

### DIFF
--- a/title_notifier.js
+++ b/title_notifier.js
@@ -13,7 +13,7 @@
 ;(function() {
   var title = document.getElementsByTagName('title')[0],
       notificationTotal = 0,
-      patt = /\(\d*\) /;
+      patt = /^\(\d*\) /;
 
   function updateTitle() {
     if(notificationTotal === 0) {


### PR DESCRIPTION
Without this you could end up mutating titles like "Foo bar baz (10) " to "Foo bar baz" which may be unexpected since the examples show the number always appearing/changing at the start of the title.
